### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -2,4 +2,6 @@ version: 2.1
 
 description: >
   Easily send build results to Opsgenie API, with detailed information.
-  View this orb's source: https://github.com/opsgenie/opsgenie-orb
+display:
+  home_url:  https://www.atlassian.com/software/opsgenie
+  source_url: https://github.com/opsgenie/opsgenie-orb


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.