### PR TITLE
Make the default image for executor stable

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -5,7 +5,7 @@ docker:
   - image: <<parameters.docker-image>>
 parameters:
   docker-image:
-    default: cimg/base
+    default: cimg/base:stable
     description: |
       Docker image to use in this executor, defaults to cimg/base
     type: string


### PR DESCRIPTION
Running this with the default executor will throw a:
```
Error response from daemon: manifest for cimg/base:latest not found
```

(See Tagging Scheme https://hub.docker.com/r/cimg/base)